### PR TITLE
deleting second buddypress validation

### DIFF
--- a/class/wc4bp-manager.php
+++ b/class/wc4bp-manager.php
@@ -196,7 +196,7 @@ class wc4bp_Manager {
 	public static function is_buddypress_active() {
 		self::load_plugins_dependency();
 
-		return is_plugin_active( 'buddypress/bp-loader.php' ) && function_exists( 'buddypress' );
+		return is_plugin_active( 'buddypress/bp-loader.php' );
 	}
 
 	public static function is_buddyboss_theme_active() {


### PR DESCRIPTION
Second buddypress validation deleted because is failing in some cases.